### PR TITLE
Update LSP settings for Haskell

### DIFF
--- a/addons/lspclient/settings.json
+++ b/addons/lspclient/settings.json
@@ -34,9 +34,9 @@
             "highlightingModeRegex": "^Go$"
         },
         "haskell": {
-            "command": ["hie-wrapper"],
+            "command": ["haskell-language-server-wrapper", "--lsp"],
             "rootIndicationFileNames": ["*.cabal", "stack.yaml", "cabal.project", "package.yaml"],
-            "url": "https://github.com/haskell/haskell-ide-engine",
+            "url": "https://github.com/haskell/haskell-language-server",
             "highlightingModeRegex": "^Haskell$"
         },
         "javascript": {


### PR DESCRIPTION
This updates to the latest commands for use with Haskell's modern LSP implementation. This has been tested with `kate-20.08.3` on my system.