### PR TITLE
More simplier regexp to match different class declarations

### DIFF
--- a/addons/symbolviewer/python_parser.cpp
+++ b/addons/symbolviewer/python_parser.cpp
@@ -73,7 +73,7 @@ void KatePluginSymbolViewerView::parsePythonSymbols(void)
             }
         }
 
-        if (cl.indexOf(QRegularExpression(QLatin1String("^class [a-zA-Z0-9_,\\s\\(\\).]+:"))) >= 0) {
+        if (cl.indexOf(QRegularExpression(QLatin1String("^class ([a-zA-Z0-9_]+)(\(.*\))?:"))) >= 0) {
             in_class = 1;
         }
 


### PR DESCRIPTION
Like:

class Philosopher:
class AustralianPhilosopher(Philosopher, default_name):
class Meta():
class MyClass(metaclass=Meta):
class MySubclass(MyClass):

Fix case where AustralianPhilosopher is not detected