### PR TITLE
Update settings.json for the Default LSP Settings

### DIFF
--- a/addons/lspclient/settings.json
+++ b/addons/lspclient/settings.json
@@ -17,8 +17,8 @@
             "highlightingModeRegex": "^(C|ANSI C89|Objective-C)$"
         },
         "css": {
-            "command": ["vscode-css-languageserver", "--stdio"],
-            "url": "https://github.com/Microsoft/vscode/tree/main/extensions/css-language-features/server",
+            "command": ["vscode-css-language-server", "--stdio"],
+            "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
             "highlightingModeRegex": "^CSS$"
         },
         "cpp": {
@@ -100,8 +100,8 @@
             "highlightingModeRegex": "^Haskell$"
         },
         "html": {
-            "command": ["vscode-html-languageserver", "--stdio"],
-            "url": "https://github.com/Microsoft/vscode/tree/main/extensions/html-language-features/server",
+            "command": ["vscode-html-language-server", "--stdio"],
+            "url": "https://github.com/hrsh7th/vscode-langservers-extracted",
             "highlightingModeRegex": "^HTML$"
         },
         "java": {


### PR DESCRIPTION
`CSS` and `HTML` Language Servers

the invocation of the server:

```json
"command": ["vscode-css-languageserver", "--stdio"], 
```

makes reference to:

```json
"url": "https://github.com/Microsoft/vscode/tree/main/extensions/css-language-features/server",
```

but the cited reference does not provide an elucidated methodology to globally install an executable `CLI` binary that is invoked by the command:

```sh
>_ vscode-css-languageserver
```

Reference Implementations of the Proposed LSPs in Code Editor(s): [LSP Mode - LSP support for Emacs](https://emacs-lsp.github.io/lsp-mode/page/languages/) 
CSS: https://emacs-lsp.github.io/lsp-mode/page/lsp-css/ 
HTML: https://emacs-lsp.github.io/lsp-mode/page/lsp-html/

Source:
https://github.com/hrsh7th/vscode-langservers-extracted